### PR TITLE
Disable tests for NodeBackend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
         run: |
           echo "Testing NodeBackend..."
           cd NodeBackend/build
-          ctest --output-on-failure || echo "No tests found."
+          echo "Deactivated as there are currently no test cases for the NodeBackend"
+          # ctest --output-on-failure || echo "No tests found."
 
   # ============================================
   # WebUI Jobs


### PR DESCRIPTION
This PR disables the tests for the NodeBackend Component, as there are no tests to run, and the test script contains an error which fails in the weekly tests